### PR TITLE
fix json server port problem

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "yarn gen:type && next build",
     "start": "next start",
     "lint": "next lint",
-    "start-json-server": "json-server --watch db.json ---port 5000"
+    "start-json-server": "json-server --watch db.json ---port 4000"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.2.4",


### PR DESCRIPTION
Previously, we ran the mock api (json server) on the localhost:5000. Unfortunately, with the latest update of macOS v12 (Monterey), we're no longer able to use that port.

Related link =>
- https://stackoverflow.com/questions/69818376/localhost5000-unavailable-in-macos-v12-monterey/69829313#69829313
- https://stackoverflow.com/questions/70913242/access-to-localhost-was-denied-you-dont-have-authorisation-to-view-this-page-h
