### PR TITLE
ajdust db.json for the flexible rest api

### DIFF
--- a/frontend/db.json
+++ b/frontend/db.json
@@ -1,41 +1,33 @@
 {
-  "billings": {
-    "data": [
-      {
-        "id": "1",
-        "title": "Iuran Minyak Goreng",
-        "amount": 25.0
-      },
-      {
-        "id": "2",
-        "title": "Iuran Beras 50Kg",
-        "amount": 50.0
-      },
-      {
-        "id": "2",
-        "title": "Iuran belanja mingguan",
-        "amount": 200.0
-      }
-    ],
-    "status": "success",
-    "message": "success"
-  },
-  "members": {
-    "data": [
-      {
-        "id": "1",
-        "name": "M. Nindra Zaka"
-      },
-      {
-        "id": "2",
-        "name": "Ilham Surya P."
-      },
-      {
-        "id": "3",
-        "name": "Danny Dwi C"
-      }
-    ],
-    "status": "success",
-    "message": "success"
-  }
+  "billings": [
+    {
+      "id": "1",
+      "title": "Iuran Minyak Goreng",
+      "amount": 25.0
+    },
+    {
+      "id": "2",
+      "title": "Iuran Beras 50Kg",
+      "amount": 50.0
+    },
+    {
+      "id": "2",
+      "title": "Iuran belanja mingguan",
+      "amount": 200.0
+    }
+  ],
+  "members": [
+    {
+      "id": "1",
+      "name": "M. Nindra Zaka"
+    },
+    {
+      "id": "2",
+      "name": "Ilham Surya P."
+    },
+    {
+      "id": "3",
+      "name": "Danny Dwi C"
+    }
+  ]
 }


### PR DESCRIPTION
## Background Summary
With our current `db.json` implementation, we can't get the mock be response with the plural routes. For instance, if we want to get the billing detail data with id 1, we can easily do that by accessing `/billings/1`, however, if we structure our db.json becomes =>
```
"billings": {
    "data": [
      {
        "id": "1",
        "title": "Iuran Minyak Goreng",
        "amount": 25
      },
    ],
    "status": "success",
    "message": "success"
  },
```
We can't get billing detail by accessing `/billings/1` or filtering specifically `billings?amount=25`.

Related link =>
https://www.npmjs.com/package/json-server#plural-routes