### PR TITLE
fix: adding wrapper title page to be on the top

### DIFF
--- a/frontend/src/containers/Billings/BillingList.tsx
+++ b/frontend/src/containers/Billings/BillingList.tsx
@@ -13,7 +13,7 @@ const BillingList = ({ billings, send }: Props) => {
     send({
       type: "ACTIVATE_BILLING_FORM",
       formMode: FormMode.Create,
-      billingId: null,
+      billingId: null
     });
   };
 
@@ -21,16 +21,18 @@ const BillingList = ({ billings, send }: Props) => {
     send({
       type: "ACTIVATE_BILLING_FORM",
       formMode: FormMode.Edit,
-      billingId,
+      billingId
     });
   };
 
   return (
-    <Box m="4" color="gray.200" mb="36">
-      <Heading as="h3" textAlign="center" my="6" color="gray.700">
-        Billings
-      </Heading>
-      <VStack spacing="4">
+    <Box color="gray.200" mb="36">
+      <Box width="full" bg="white" h="20" position="fixed" left="0" right="0">
+        <Heading as="h3" textAlign="center" my="6" color="gray.700">
+          Billings
+        </Heading>
+      </Box>
+      <VStack spacing="4" pt="24">
         {billings.map((billing) => (
           <Box
             key={billing.id}

--- a/frontend/src/containers/MembersPage/MemberList.tsx
+++ b/frontend/src/containers/MembersPage/MemberList.tsx
@@ -8,23 +8,23 @@ const MemberList = () => {
   const query = useQuery("Members", () => membersApi.getMemberList());
 
   return (
-    <Box m={"4"} color={"gray.200"} mb={"36"}>
-      <VStack spacing={"4"}>
+    <Box mt="24" color="gray.200" mb="36">
+      <VStack spacing="4">
         {match(query)
           .with({ status: "success" }, (query) =>
             query.data.data.map((member) => {
               return (
                 <Box
                   key={member.id}
-                  border={"1px"}
-                  borderRadius={"16px"}
-                  p={"6"}
-                  w={"full"}
-                  backgroundColor={"gray.700"}
-                  cursor={"pointer"}
+                  border="1px"
+                  borderRadius="16px"
+                  p="6"
+                  w="full"
+                  backgroundColor="gray.700"
+                  cursor="pointer"
                 >
                   <Link href={`/payments/${member.id}`}>
-                    <Text fontSize={"2xl"} fontWeight={"semibold"}>
+                    <Text fontSize="2xl" fontWeight="semibold">
                       {member.name}
                     </Text>
                   </Link>

--- a/frontend/src/containers/MembersPage/MembersPage.tsx
+++ b/frontend/src/containers/MembersPage/MembersPage.tsx
@@ -6,10 +6,12 @@ import Layout from "../../components/Layout";
 const MembersPage = () => {
   return (
     <Layout>
-      <Box width={"full"}>
-        <Heading color="gray.700" as={"h3"} textAlign={"center"} my={"6"}>
-          Members
-        </Heading>
+      <Box width="full">
+        <Box width="full" bg="white" h="20" position="fixed" left="0" right="0">
+          <Heading color="gray.700" as="h3" my="6" textAlign="center">
+            Members
+          </Heading>
+        </Box>
         <MemberList />
         <BottomMenu activeMenu="members" />
       </Box>

--- a/frontend/src/containers/PaymentsPage/PaymentList.tsx
+++ b/frontend/src/containers/PaymentsPage/PaymentList.tsx
@@ -9,26 +9,26 @@ interface PaymentListProps {
 
 const PaymentList = (props: PaymentListProps) => {
   return (
-    <Box m={"4"} color={"gray.200"} mb={"36"}>
+    <Box mt="24" color="gray.200" mb="36">
       <Heading as="h5" color="gray.700" fontSize="xl" my="4">
         {`${props.member.name}'s payment`}
       </Heading>
-      <VStack spacing={"4"}>
+      <VStack spacing="4">
         {props.payments.map((payment) => (
           <Box
             key={payment.memberId}
-            border={"1px"}
-            borderRadius={"16px"}
-            p={"6"}
-            w={"full"}
-            backgroundColor={"gray.700"}
-            cursor={"pointer"}
-            display={"flex"}
-            justifyContent={"space-between"}
-            alignItems={"center"}
+            border="1px"
+            borderRadius="16px"
+            p="6"
+            w="full"
+            backgroundColor="gray.700"
+            cursor="pointer"
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
             onClick={() => props.onItemClick(payment)}
           >
-            <Text fontSize={"2xl"} fontWeight={"semibold"}>
+            <Text fontSize="2xl" fontWeight="semibold">
               {payment.name}
             </Text>
             <Text>Rp. {payment.amount}</Text>

--- a/frontend/src/containers/PaymentsPage/PaymentsPage.tsx
+++ b/frontend/src/containers/PaymentsPage/PaymentsPage.tsx
@@ -22,9 +22,18 @@ const PaymentsPage = (props: PaymentsPageProps) => {
     <Layout>
       <Box width="full">
         <>
-          <Heading as="h3" textAlign="center" my="6" color="gray.700">
-            Payments
-          </Heading>
+          <Box
+            width="full"
+            bg="white"
+            h="20"
+            position="fixed"
+            left="0"
+            right="0"
+          >
+            <Heading as="h3" textAlign="center" my="6" color="gray.700">
+              Payments
+            </Heading>
+          </Box>
           {match<State.t>(state as State.t)
             .with({ value: "idle" }, () => <GeneralLoading />)
             .with({ value: "fetchingMember" }, () => <GeneralLoading />)
@@ -45,7 +54,7 @@ const PaymentsPage = (props: PaymentsPageProps) => {
                   onItemClick={(payment) =>
                     send({
                       type: "SELECT_PAYMENT_TARGET",
-                      targetMemberId: payment.memberId,
+                      targetMemberId: payment.memberId
                     })
                   }
                 />


### PR DESCRIPTION
changes

- adding wrapper title page to be on the top on `Members`, `Payment`, and `Billings`
![Screenshot_20221005_195356](https://user-images.githubusercontent.com/56879512/194066085-d1021cba-0ba9-4835-9c12-4c225b224edf.png)
