### PR TITLE
fix: scroll on billing form second step

### DIFF
--- a/frontend/src/containers/Billings/BillingForm__SecondStep.tsx
+++ b/frontend/src/containers/Billings/BillingForm__SecondStep.tsx
@@ -73,7 +73,7 @@ const BillingFormSecondStep = ({ members, send, billingForm }: Props) => {
               Bill Equally
             </Checkbox>
           </Flex>
-          <VStack spacing="4" my="4">
+          <VStack spacing="4" my="4" h="lg" overflowY="scroll">
             {filteredMembers.map((member, index) => (
               <Box
                 key={member.id}


### PR DESCRIPTION
related #74 

changes

- adding `height` and `overflowY` on the wrapper list member billing form second step


https://user-images.githubusercontent.com/56879512/196018548-1a1ea185-2cf6-4b3c-a1fb-6465d3c9a60d.mp4

